### PR TITLE
Убираем рантайм

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -444,7 +444,9 @@ var/global/list/activated_medevac_stretchers = list()
 
 /obj/structure/bed/roller/hospital/Initialize(mapload, ...)
 	. = ..()
+/*RUCM REMOVAL // runtime because don't setup preferences to body
 	create_body()
+*/
 	update_icon()
 
 /obj/structure/bed/roller/hospital/Destroy()


### PR DESCRIPTION
# About the pull request

Убирает рантайм на который ругается при компиляции, тело что создаётся на коляске не имеет никаких настроек, из за чего не может создаться, вызывая ошибку. Функция ничего не делала, так что и смысла её держать нету

# Explain why it's good for the game

Неопытные юзеры ВСК смогут закомпилить билд без отключения галочки


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
refactor: Убран рантайм с гибризы
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
